### PR TITLE
Add minimal beans descriptor for Weld

### DIFF
--- a/src/main/webapp/WEB-INF/beans.xml
+++ b/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.1" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       bean-discovery-mode="all">
+</beans>


### PR DESCRIPTION
## Summary
- add `WEB-INF/beans.xml` with a minimal configuration for CDI

## Testing
- `mvn -ntp install -DskipTests` *(fails: could not resolve Maven plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6869f4b686448324aaef48c8ce1dcfa1