### PR TITLE
Mark CDI dependencies as provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,11 +62,13 @@
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
             <version>2.0.1</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <version>4.0.1</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.platform</groupId>
@@ -186,7 +188,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>copy-resources</id>


### PR DESCRIPTION
## Summary
- mark Jakarta CDI dependencies with `provided` scope
- adjust resources plugin to version 3.3.0

## Testing
- `mvn -q package` *(fails: Plugin resolution failed due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6869f74429908324aece2f67dd80609f