### PR TITLE
Use container transactions for BajaUbicacionBean

### DIFF
--- a/src/main/java/codigocreativo/uy/servidorapp/servicios/BajaUbicacionBean.java
+++ b/src/main/java/codigocreativo/uy/servidorapp/servicios/BajaUbicacionBean.java
@@ -12,8 +12,6 @@ import codigocreativo.uy.servidorapp.excepciones.ServiciosException;
 
 import jakarta.ejb.EJB;
 import jakarta.ejb.Stateless;
-import jakarta.ejb.TransactionManagement;
-import jakarta.ejb.TransactionManagementType;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -22,7 +20,6 @@ import jakarta.transaction.Transactional;
 import java.io.Serializable;
 import java.util.List;
 
-@TransactionManagement(TransactionManagementType.BEAN)
 @Stateless
 public class BajaUbicacionBean implements BajaUbicacionRemote {
     @PersistenceContext(unitName = "servidorappPU")


### PR DESCRIPTION
## Summary
- remove manual transaction management annotations
- rely on container managed transactions for `BajaUbicacionBean`

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact maven-resources-plugin due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686b63777a38832484f62ca6e9c2d6db