### PR TITLE
Fix duplicated deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,11 +37,6 @@
             <version>6.2.4.Final</version>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.jaxb</groupId>
-            <artifactId>jaxb-runtime</artifactId>
-            <version>4.0.2</version>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>${junit.version}</version>
@@ -91,22 +86,22 @@
         <dependency>
     <groupId>com.fasterxml.jackson.core</groupId>
     <artifactId>jackson-databind</artifactId>
-    <version>2.13.4.1</version>
+    <version>2.17.0</version>
 </dependency>
 <dependency>
     <groupId>com.fasterxml.jackson.core</groupId>
     <artifactId>jackson-core</artifactId>
-    <version>2.13.3</version>
+    <version>2.17.0</version>
 </dependency>
 <dependency>
     <groupId>com.fasterxml.jackson.core</groupId>
     <artifactId>jackson-annotations</artifactId>
-    <version>2.13.3</version>
+    <version>2.17.0</version>
 </dependency>
 <dependency>
     <groupId>com.fasterxml.jackson.datatype</groupId>
     <artifactId>jackson-datatype-jsr310</artifactId>
-    <version>2.13.3</version>
+    <version>2.17.0</version>
 </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
@@ -144,11 +139,6 @@
             <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
-<dependency>
-    <groupId>com.fasterxml.jackson.datatype</groupId>
-    <artifactId>jackson-datatype-jsr310</artifactId>
-    <version>2.15.4</version>
-</dependency>
 
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>


### PR DESCRIPTION
## Summary
- remove outdated `jaxb-runtime` dependency
- synchronize Jackson dependencies to version 2.17.0

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:3.2.0)*

------
https://chatgpt.com/codex/tasks/task_e_686b693164e483248c45a5042e262470